### PR TITLE
fixes node_win_onecore gyp issues on windows - missing variable and needs default of 0

### DIFF
--- a/deps/leveldb/leveldb.gyp
+++ b/deps/leveldb/leveldb.gyp
@@ -1,7 +1,8 @@
 {'targets': [{
     'target_name': 'leveldb'
   , 'variables': {
-        'ldbversion': '1.17.0'
+        'ldbversion': '1.17.0',
+        'node_win_onecore' : 0
     }
   , 'type': 'static_library'
     # Overcomes an issue with the linker and thin .a files on SmartOS


### PR DESCRIPTION
this fixes builds on windows that are throwing the following error:

```
gyp: name 'node_win_onecore' is not defined while evaluating condition 'node_win_onecore==1' in D:\g\jxcore-dist\node_modules\leveldown-mobile\deps\leveldb\leveldb.gyp while loading dependencies of binding.gyp while trying to load binding.gyp
```

More details...
[npm-debug.txt](https://github.com/Level/leveldown-mobile/files/199999/npm-debug.txt)


```
D:\g\jxcore-dist\node_modules\leveldown-mobile>if not defined npm_config_node_gyp (node "C:\Users\Shawn\.jx\npm\bin\node-gyp-bin\\..\..\node_modules\node-gyp\bin\node-gyp.js" rebuild )  else (node  rebuild )
gyp: name 'node_win_onecore' is not defined while evaluating condition 'node_win_onecore==1' in D:\g\jxcore-dist\node_modules\leveldown-mobile\deps\leveldb\leveldb.gyp while loading dependencies of binding.gyp while trying to load binding.gyp
gyp ERR! configure error
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (C:\Users\Shawn\.jx\npm\node_modules\node-gyp\lib\configure.js:355:16)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Windows_NT 10.0.10586
gyp ERR! command "C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\Shawn\\.jx\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebui
```